### PR TITLE
Add in test for functions within mixins

### DIFF
--- a/test/unit/function.js
+++ b/test/unit/function.js
@@ -244,3 +244,23 @@ test('not modify arguments by direct assignment', function() {
 		'}',
 	]);
 });
+
+test('function called within a mixin', function() {
+	assert.compileTo([
+		'$foo = @function {',
+		'	width: $bar();',
+		'};',
+		'',
+		'$bar = @function {',
+		'	@return 80px;',
+		'};',
+		'',
+		'body {',
+		'	@mixin $foo();',
+		'}',
+	], [
+		'body {',
+		'	width: 80px;',
+		'}',
+	]);
+});


### PR DESCRIPTION
This is just a test to show that functions cannot be called within a mixin. 

It will break travis, until this is fixed. 
